### PR TITLE
Adaptive card extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ Merging is done with `array_merge_recursive`:
 > same numeric key, the later value will not overwrite the original value, but
 > will be appended.
 
+### Shipped extensions
+
+-   `AdaptiveCardExtension\MicrosoftTeams\FullWidth`
+    You can use the `msteams` property to expand the width of an Adaptive Card
+    and make use of extra canvas space. The next section provides information
+    on how to use the property.
+-   `AdaptiveCardExtension\MicrosoftTeams\AllowExpand`
+    In an Adaptive Card, you can use the `msteams` property to add the ability
+    to display images in Stageview selectively. When users hover over the
+    images, they can see an expand icon, for which the allowExpand attribute is
+    set to 'true`.
+-   `AdaptiveCardExtension\MicrosoftTeams\Mention`
+    You can add @mentions within an Adaptive Card body for bots and message
+    extension responses. To add @mentions in cards, follow the same
+    notification logic and rendering as that of message based mentions in
+    channel and group chat conversations.
+
 ### Create your own extensions
 
 -   Find the interface for the element you want to extend

--- a/README.md
+++ b/README.md
@@ -40,6 +40,30 @@ $card->actions = [
 ];
 ```
 
+## Extensions
+
+All elements have an extensions property to inject custom properties into the
+elements; for every element there is an unique interface, so injecting
+extensions for the wrong element is not possible.
+
+The extensions exist as a stopgap for missing properties in the schema. There
+is currently no up-to-date schema available.
+
+Merging is done with `array_merge_recursive`:
+
+> If the input arrays have the same string keys, then the values for these keys
+> are merged together into an array, and this is done recursively, so that if
+> one of the values is an array itself, the function will merge it with a
+> corresponding entry in another array too. If, however, the arrays have the
+> same numeric key, the later value will not overwrite the original value, but
+> will be appended.
+
+### Create your own extensions
+
+-   Find the interface for the element you want to extend
+-   Create a class that implements that interface
+-   Add the extension to the constructor of the element
+
 ## How to generate
 
 -   Clone this repo

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     },
     "autoload": {
         "psr-4": {
-            "AdaptiveCard\\": "src"
+            "AdaptiveCard\\": "src",
+            "AdaptiveCardExtension\\": "extension"
         }
     },
     "autoload-dev": {

--- a/extension/MicrosoftTeams/AllowExpand.php
+++ b/extension/MicrosoftTeams/AllowExpand.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdaptiveCardExtension\MicrosoftTeams;
+
+use AdaptiveCard\Extension\ImageExtensionInterface;
+use Override;
+
+/**
+ * Stageview for images in Adaptive Cards
+ *
+ * In an Adaptive Card, you can use the `msteams` property to add the ability
+ * to display images in Stageview selectively. When users hover over the
+ * images, they can see an expand icon, for which the allowExpand attribute is
+ * set to 'true`.
+ */
+class AllowExpand implements ImageExtensionInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    #[Override]
+    public function getExtensionProperties(): array
+    {
+        return [
+            'msteams' => [
+                'allowExpand' => true,
+            ],
+        ];
+    }
+}

--- a/extension/MicrosoftTeams/FullWidth.php
+++ b/extension/MicrosoftTeams/FullWidth.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdaptiveCardExtension\MicrosoftTeams;
+
+use AdaptiveCard\Extension\AdaptiveCardExtensionInterface;
+use Override;
+
+/**
+ * Full width Adaptive Card
+ *
+ * You can use the `msteams` property to expand the width of an Adaptive Card
+ * and make use of extra canvas space. The next section provides information
+ * on how to use the property.
+ */
+class FullWidth implements AdaptiveCardExtensionInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    #[Override]
+    public function getExtensionProperties(): array
+    {
+        return [
+            'msteams' => [
+                'width' => 'Full',
+            ],
+        ];
+    }
+}

--- a/extension/MicrosoftTeams/Mention.php
+++ b/extension/MicrosoftTeams/Mention.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdaptiveCardExtension\MicrosoftTeams;
+
+use AdaptiveCard\Extension\AdaptiveCardExtensionInterface;
+use Override;
+
+/**
+ * Mention support within Adaptive Cards
+ *
+ * You can add @mentions within an Adaptive Card body for bots and message
+ * extension responses. To add @mentions in cards, follow the same
+ * notification logic and rendering as that of message based mentions in
+ * channel and group chat conversations.
+ */
+class Mention implements AdaptiveCardExtensionInterface
+{
+    /**
+     * Must be `mention`
+     */
+    private const TYPE = 'mention';
+
+    /**
+     * The text to be displayed for the @mention. This is required and must be in the format of `<at>display name</at>`.
+     */
+    private string $text;
+
+    /**
+     * The unique identifier of the entity being mentioned.
+     */
+    private string $id;
+
+    /**
+     * The name of the entity being mentioned.
+     */
+    private string $name;
+
+    public function __construct(string $text, string $id, string $name)
+    {
+        $this->text = $text;
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[Override]
+    public function getExtensionProperties(): array
+    {
+        return [
+            'msteams' => [
+                'entities' => [
+                    [
+                        'type' => self::TYPE,
+                        'text' => $this->text,
+                        'mentioned' => [
+                            'id' => $this->id,
+                            'name' => $this->name,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/generator/src/Command/GenerateCommand.php
+++ b/generator/src/Command/GenerateCommand.php
@@ -71,6 +71,8 @@ final class GenerateCommand
     private const SCHEMA = 'http://adaptivecards.io/schemas/adaptive-card.json';
     private const BASE_NAMESPACE = 'AdaptiveCard';
 
+    private const EXTENSION_INTERFACE_SUFFIX = 'ExtensionInterface';
+
     public function __invoke(): int
     {
         $filesystem = new Filesystem();
@@ -162,11 +164,23 @@ final class GenerateCommand
                 continue;
             }
 
+            $extensionInterface = $this->generateExtensionInterface(
+                $definitionName,
+                $definition,
+            );
+
+            if ($extensionInterface !== null) {
+                $generated[
+                    $definitionName . self::EXTENSION_INTERFACE_SUFFIX
+                ] = $extensionInterface;
+            }
+
             $generated[$definitionName] = $this->generatePhpFile(
                 $definitionName,
                 $definition,
                 $implementations,
                 $parentProperties,
+                $extensionInterface,
             );
         }
 
@@ -236,6 +250,7 @@ final class GenerateCommand
      * @psalm-param TDefinition $definition
      * @param array<string, array<array{string, PhpFile, ...}>> $implementations
      * @psalm-param array<string, array<array{fullType: string, property: Property}>> $parentProperties
+     * @psalm-param ?array{string, PhpFile, array<array{fullType: string, property: Property}>} $extensionInterface
      * @return array{string, PhpFile, array<array{fullType: string, property: Property}>}
      */
     private function generatePhpFile(
@@ -243,6 +258,7 @@ final class GenerateCommand
         array $definition,
         array $implementations,
         array $parentProperties,
+        ?array $extensionInterface = null,
     ): array {
         $phpFile = new PhpFile();
         $phpFile->setStrictTypes(true);
@@ -366,15 +382,45 @@ final class GenerateCommand
             $ownProperties = [];
         }
 
+        $hasExtensions = false;
+
         if (!$isExtentable) {
+            $extensionsProperties = [];
+
+            if ($extensionInterface !== null) {
+                $phpNamespace->addUse($extensionInterface[0]);
+
+                $extensionsProperty = $phpClass->addProperty('extensions');
+                $extensionsProperty->setPublic();
+                $extensionsProperty->setNullable();
+                $extensionsProperty->setType('array');
+                $extensionsProperty->addComment(
+                    'Extensions to augment this element',
+                );
+                $extensionsProperty->addComment('');
+
+                $fullType =
+                    $phpNamespace->simplifyType($extensionInterface[0]) . '[]';
+                $extensionsProperty->addComment('@var ' . $fullType . '|null');
+
+                $extensionsProperties[] = [
+                    'fullType' => $fullType,
+                    'property' => $extensionsProperty,
+                ];
+
+                $hasExtensions = true;
+            }
+
             $this->addTheConstructor($phpClass, [
                 ...$ownProperties,
                 ...$currentParentProperties,
+                ...$extensionsProperties,
             ]);
 
             $this->addTheMaker($phpClass, [
                 ...$ownProperties,
                 ...$currentParentProperties,
+                ...$extensionsProperties,
             ]);
         }
 
@@ -384,6 +430,7 @@ final class GenerateCommand
             hasSchema: $hasSchema,
             isExtending: $isExtending,
             ownProperties: $ownProperties,
+            hasExtensions: $hasExtensions,
         );
 
         return [$fullClassName, $phpFile, $ownProperties];
@@ -543,6 +590,22 @@ final class GenerateCommand
         }
 
         return [$hasType, $hasSchema, $ownProperties];
+    }
+
+    /**
+     * @psalm-param TDefinition $definition
+     */
+    private function isEnum(array $definition): bool
+    {
+        if (isset($definition['anyOf'])) {
+            foreach ($definition['anyOf'] as $type) {
+                if (isset($type['enum'])) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -733,6 +796,7 @@ final class GenerateCommand
         bool $hasSchema,
         bool $isExtending,
         array $ownProperties,
+        bool $hasExtensions,
     ): void {
         $phpMethod = $phpClass->addMethod('jsonSerialize');
         $phpMethod->addComment(
@@ -740,12 +804,29 @@ final class GenerateCommand
         );
         $phpMethod->setReturnType('array');
 
+        $body = '';
+
+        if ($hasExtensions) {
+            $body .= <<<BODY
+            \$extensionProperties = [];
+
+            foreach (\$this->extensions ?? [] as \$extension) {
+                \$extensionProperties = array_merge_recursive(
+                    \$extensionProperties,
+                    \$extension->getExtensionProperties(),
+                );
+            }
+
+
+            BODY;
+        }
+
         if ($isExtending) {
-            $body = <<<BODY
+            $body .= <<<BODY
             return array_merge(parent::jsonSerialize(), array_filter([
             BODY;
         } else {
-            $body = <<<BODY
+            $body .= <<<BODY
             return array_filter([
             BODY;
         }
@@ -774,6 +855,13 @@ final class GenerateCommand
             $body .= <<<BODY
 
                 '$fieldName' => \$this->$propertyName,
+            BODY;
+        }
+
+        if ($hasExtensions) {
+            $body .= <<<BODY
+
+                ...\$extensionProperties,
             BODY;
         }
 
@@ -812,6 +900,65 @@ final class GenerateCommand
 
         $node->addComment((string) $descriptionParts);
         $node->addComment('');
+    }
+
+    /**
+     * @param string $definitionName
+     * @param array $definition
+     * @psalm-param TDefinition $definition
+     * @return ?array{string, PhpFile, array<array{fullType: string, property: Property}>}
+     */
+    private function generateExtensionInterface(
+        string $definitionName,
+        array $definition,
+    ): ?array {
+        $phpFile = new PhpFile();
+        $phpFile->setStrictTypes(true);
+
+        $phpFile->addComment(
+            'This is a generated file, do not modify this by hand.',
+        );
+
+        $namespace = self::BASE_NAMESPACE . '\\Extension';
+
+        $className = (string) preg_replace(
+            ['/^Extendable\./', '/^ImplementationsOf\.(.*)$/'],
+            ['', '$1Interface'],
+            $definitionName,
+        );
+
+        if (str_contains($className, '.')) {
+            $namespaceParts = explode('.', $className);
+            $className = array_pop($namespaceParts);
+
+            if (!empty($namespaceParts)) {
+                $namespace .= '\\' . implode('\\', $namespaceParts);
+            }
+        }
+
+        $isExtentable = str_contains($definitionName, 'Extendable.');
+        $isInterface = str_contains($definitionName, 'ImplementationsOf.');
+        $isEnum = $this->isEnum($definition);
+
+        if ($isExtentable || $isInterface || $isEnum) {
+            return null;
+        }
+
+        $className .= self::EXTENSION_INTERFACE_SUFFIX;
+
+        $phpNamespace = $phpFile->addNamespace($namespace);
+        $phpInterface = $phpNamespace->addInterface($className);
+
+        $phpMethod = $phpInterface->addMethod('getExtensionProperties');
+        $phpMethod->setPublic();
+        $phpMethod->setReturnType('array');
+        $phpMethod->addComment(
+            'Get additional properties for the extension. These will be merged with the main properties of the class.',
+        );
+        $phpMethod->addComment('');
+        $phpMethod->addComment('@return array<string, mixed>');
+
+        return [$phpNamespace->resolveName($className), $phpFile, []];
     }
 
     /**

--- a/src/Action/Execute.php
+++ b/src/Action/Execute.php
@@ -11,6 +11,7 @@ namespace AdaptiveCard\Action;
 use AdaptiveCard\Action;
 use AdaptiveCard\ActionInterface;
 use AdaptiveCard\AssociatedInputs;
+use AdaptiveCard\Extension\Action\ExecuteExtensionInterface;
 use AdaptiveCard\ISelectActionInterface;
 use AdaptiveCard\ItemInterface;
 use JsonSerializable;
@@ -62,7 +63,16 @@ final class Execute extends Action implements
     public ?AssociatedInputs $associatedInputs = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var ExecuteExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "Execute" instance in a single call
+     *
+     * @param ExecuteExtensionInterface[]|null $extensions
      */
     public function __construct(
         ?string $verb = null,
@@ -76,6 +86,7 @@ final class Execute extends Action implements
         ?string $tooltip = null,
         ?bool $isEnabled = null,
         ?\AdaptiveCard\ActionMode $mode = null,
+        ?array $extensions = null,
     ) {
         $this->verb = $verb;
         $this->data = $data;
@@ -88,12 +99,15 @@ final class Execute extends Action implements
         $this->tooltip = $tooltip;
         $this->isEnabled = $isEnabled;
         $this->mode = $mode;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "Execute" instance in a single call
      *
      * @psalm-api
+     *
+     * @param ExecuteExtensionInterface[]|null $extensions
      */
     public static function make(
         ?string $verb = null,
@@ -107,6 +121,7 @@ final class Execute extends Action implements
         ?string $tooltip = null,
         ?bool $isEnabled = null,
         ?\AdaptiveCard\ActionMode $mode = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $verb,
@@ -120,6 +135,7 @@ final class Execute extends Action implements
             $tooltip,
             $isEnabled,
             $mode,
+            $extensions,
         );
     }
 
@@ -128,6 +144,15 @@ final class Execute extends Action implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
@@ -136,6 +161,7 @@ final class Execute extends Action implements
                     'verb' => $this->verb,
                     'data' => $this->data,
                     'associatedInputs' => $this->associatedInputs,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/Action/OpenUrl.php
+++ b/src/Action/OpenUrl.php
@@ -10,6 +10,7 @@ namespace AdaptiveCard\Action;
 
 use AdaptiveCard\Action;
 use AdaptiveCard\ActionInterface;
+use AdaptiveCard\Extension\Action\OpenUrlExtensionInterface;
 use AdaptiveCard\ISelectActionInterface;
 use AdaptiveCard\ItemInterface;
 use JsonSerializable;
@@ -41,7 +42,16 @@ final class OpenUrl extends Action implements
     public string $url;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var OpenUrlExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "OpenUrl" instance in a single call
+     *
+     * @param OpenUrlExtensionInterface[]|null $extensions
      */
     public function __construct(
         string $url,
@@ -53,6 +63,7 @@ final class OpenUrl extends Action implements
         ?string $tooltip = null,
         ?bool $isEnabled = null,
         ?\AdaptiveCard\ActionMode $mode = null,
+        ?array $extensions = null,
     ) {
         $this->url = $url;
         $this->title = $title;
@@ -63,12 +74,15 @@ final class OpenUrl extends Action implements
         $this->tooltip = $tooltip;
         $this->isEnabled = $isEnabled;
         $this->mode = $mode;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "OpenUrl" instance in a single call
      *
      * @psalm-api
+     *
+     * @param OpenUrlExtensionInterface[]|null $extensions
      */
     public static function make(
         string $url,
@@ -80,6 +94,7 @@ final class OpenUrl extends Action implements
         ?string $tooltip = null,
         ?bool $isEnabled = null,
         ?\AdaptiveCard\ActionMode $mode = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $url,
@@ -91,6 +106,7 @@ final class OpenUrl extends Action implements
             $tooltip,
             $isEnabled,
             $mode,
+            $extensions,
         );
     }
 
@@ -99,12 +115,22 @@ final class OpenUrl extends Action implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
                 [
                     'type' => self::TYPE,
                     'url' => $this->url,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/Action/ShowCard.php
+++ b/src/Action/ShowCard.php
@@ -11,6 +11,7 @@ namespace AdaptiveCard\Action;
 use AdaptiveCard\Action;
 use AdaptiveCard\ActionInterface;
 use AdaptiveCard\AdaptiveCard;
+use AdaptiveCard\Extension\Action\ShowCardExtensionInterface;
 use AdaptiveCard\ItemInterface;
 use JsonSerializable;
 
@@ -43,7 +44,16 @@ final class ShowCard extends Action implements
     public ?AdaptiveCard $card = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var ShowCardExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "ShowCard" instance in a single call
+     *
+     * @param ShowCardExtensionInterface[]|null $extensions
      */
     public function __construct(
         ?AdaptiveCard $card = null,
@@ -55,6 +65,7 @@ final class ShowCard extends Action implements
         ?string $tooltip = null,
         ?bool $isEnabled = null,
         ?\AdaptiveCard\ActionMode $mode = null,
+        ?array $extensions = null,
     ) {
         $this->card = $card;
         $this->title = $title;
@@ -65,12 +76,15 @@ final class ShowCard extends Action implements
         $this->tooltip = $tooltip;
         $this->isEnabled = $isEnabled;
         $this->mode = $mode;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "ShowCard" instance in a single call
      *
      * @psalm-api
+     *
+     * @param ShowCardExtensionInterface[]|null $extensions
      */
     public static function make(
         ?AdaptiveCard $card = null,
@@ -82,6 +96,7 @@ final class ShowCard extends Action implements
         ?string $tooltip = null,
         ?bool $isEnabled = null,
         ?\AdaptiveCard\ActionMode $mode = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $card,
@@ -93,6 +108,7 @@ final class ShowCard extends Action implements
             $tooltip,
             $isEnabled,
             $mode,
+            $extensions,
         );
     }
 
@@ -101,12 +117,22 @@ final class ShowCard extends Action implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
                 [
                     'type' => self::TYPE,
                     'card' => $this->card,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/Action/Submit.php
+++ b/src/Action/Submit.php
@@ -11,6 +11,7 @@ namespace AdaptiveCard\Action;
 use AdaptiveCard\Action;
 use AdaptiveCard\ActionInterface;
 use AdaptiveCard\AssociatedInputs;
+use AdaptiveCard\Extension\Action\SubmitExtensionInterface;
 use AdaptiveCard\ISelectActionInterface;
 use AdaptiveCard\ItemInterface;
 use JsonSerializable;
@@ -55,7 +56,16 @@ final class Submit extends Action implements
     public ?AssociatedInputs $associatedInputs = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var SubmitExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "Submit" instance in a single call
+     *
+     * @param SubmitExtensionInterface[]|null $extensions
      */
     public function __construct(
         string|object|array|null $data = null,
@@ -68,6 +78,7 @@ final class Submit extends Action implements
         ?string $tooltip = null,
         ?bool $isEnabled = null,
         ?\AdaptiveCard\ActionMode $mode = null,
+        ?array $extensions = null,
     ) {
         $this->data = $data;
         $this->associatedInputs = $associatedInputs;
@@ -79,12 +90,15 @@ final class Submit extends Action implements
         $this->tooltip = $tooltip;
         $this->isEnabled = $isEnabled;
         $this->mode = $mode;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "Submit" instance in a single call
      *
      * @psalm-api
+     *
+     * @param SubmitExtensionInterface[]|null $extensions
      */
     public static function make(
         string|object|array|null $data = null,
@@ -97,6 +111,7 @@ final class Submit extends Action implements
         ?string $tooltip = null,
         ?bool $isEnabled = null,
         ?\AdaptiveCard\ActionMode $mode = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $data,
@@ -109,6 +124,7 @@ final class Submit extends Action implements
             $tooltip,
             $isEnabled,
             $mode,
+            $extensions,
         );
     }
 
@@ -117,6 +133,15 @@ final class Submit extends Action implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
@@ -124,6 +149,7 @@ final class Submit extends Action implements
                     'type' => self::TYPE,
                     'data' => $this->data,
                     'associatedInputs' => $this->associatedInputs,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/Action/ToggleVisibility.php
+++ b/src/Action/ToggleVisibility.php
@@ -10,6 +10,7 @@ namespace AdaptiveCard\Action;
 
 use AdaptiveCard\Action;
 use AdaptiveCard\ActionInterface;
+use AdaptiveCard\Extension\Action\ToggleVisibilityExtensionInterface;
 use AdaptiveCard\ISelectActionInterface;
 use AdaptiveCard\ItemInterface;
 use AdaptiveCard\TargetElement;
@@ -46,9 +47,17 @@ final class ToggleVisibility extends Action implements
     public array $targetElements;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var ToggleVisibilityExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "ToggleVisibility" instance in a single call
      *
      * @param TargetElement[] $targetElements
+     * @param ToggleVisibilityExtensionInterface[]|null $extensions
      */
     public function __construct(
         array $targetElements,
@@ -60,6 +69,7 @@ final class ToggleVisibility extends Action implements
         ?string $tooltip = null,
         ?bool $isEnabled = null,
         ?\AdaptiveCard\ActionMode $mode = null,
+        ?array $extensions = null,
     ) {
         $this->targetElements = $targetElements;
         $this->title = $title;
@@ -70,6 +80,7 @@ final class ToggleVisibility extends Action implements
         $this->tooltip = $tooltip;
         $this->isEnabled = $isEnabled;
         $this->mode = $mode;
+        $this->extensions = $extensions;
     }
 
     /**
@@ -78,6 +89,7 @@ final class ToggleVisibility extends Action implements
      * @psalm-api
      *
      * @param TargetElement[] $targetElements
+     * @param ToggleVisibilityExtensionInterface[]|null $extensions
      */
     public static function make(
         array $targetElements,
@@ -89,6 +101,7 @@ final class ToggleVisibility extends Action implements
         ?string $tooltip = null,
         ?bool $isEnabled = null,
         ?\AdaptiveCard\ActionMode $mode = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $targetElements,
@@ -100,6 +113,7 @@ final class ToggleVisibility extends Action implements
             $tooltip,
             $isEnabled,
             $mode,
+            $extensions,
         );
     }
 
@@ -108,12 +122,22 @@ final class ToggleVisibility extends Action implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
                 [
                     'type' => self::TYPE,
                     'targetElements' => $this->targetElements,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/ActionSet.php
+++ b/src/ActionSet.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\ActionSetExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -37,9 +38,17 @@ final class ActionSet extends Element implements
     public array $actions;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var ActionSetExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "ActionSet" instance in a single call
      *
      * @param ActionInterface[] $actions
+     * @param ActionSetExtensionInterface[]|null $extensions
      */
     public function __construct(
         array $actions,
@@ -47,12 +56,14 @@ final class ActionSet extends Element implements
         ?BlockElementHeight $height = null,
         ?bool $separator = null,
         ?Spacing $spacing = null,
+        ?array $extensions = null,
     ) {
         $this->actions = $actions;
         $this->fallback = $fallback;
         $this->height = $height;
         $this->separator = $separator;
         $this->spacing = $spacing;
+        $this->extensions = $extensions;
     }
 
     /**
@@ -61,6 +72,7 @@ final class ActionSet extends Element implements
      * @psalm-api
      *
      * @param ActionInterface[] $actions
+     * @param ActionSetExtensionInterface[]|null $extensions
      */
     public static function make(
         array $actions,
@@ -68,8 +80,16 @@ final class ActionSet extends Element implements
         ?BlockElementHeight $height = null,
         ?bool $separator = null,
         ?Spacing $spacing = null,
+        ?array $extensions = null,
     ): self {
-        return new self($actions, $fallback, $height, $separator, $spacing);
+        return new self(
+            $actions,
+            $fallback,
+            $height,
+            $separator,
+            $spacing,
+            $extensions,
+        );
     }
 
     /**
@@ -77,12 +97,22 @@ final class ActionSet extends Element implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
                 [
                     'type' => self::TYPE,
                     'actions' => $this->actions,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/AdaptiveCard.php
+++ b/src/AdaptiveCard.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\AdaptiveCardExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -142,10 +143,18 @@ final class AdaptiveCard implements JsonSerializable
     public ?VerticalContentAlignment $verticalContentAlignment = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var AdaptiveCardExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "AdaptiveCard" instance in a single call
      *
      * @param ElementInterface[]|null $body
      * @param ActionInterface[]|null $actions
+     * @param AdaptiveCardExtensionInterface[]|null $extensions
      */
     public function __construct(
         Version $version = Version::Version10,
@@ -162,6 +171,7 @@ final class AdaptiveCard implements JsonSerializable
         ?string $speak = null,
         ?string $lang = null,
         ?VerticalContentAlignment $verticalContentAlignment = null,
+        ?array $extensions = null,
     ) {
         $this->version = $version;
         $this->refresh = $refresh;
@@ -177,6 +187,7 @@ final class AdaptiveCard implements JsonSerializable
         $this->speak = $speak;
         $this->lang = $lang;
         $this->verticalContentAlignment = $verticalContentAlignment;
+        $this->extensions = $extensions;
     }
 
     /**
@@ -186,6 +197,7 @@ final class AdaptiveCard implements JsonSerializable
      *
      * @param ElementInterface[]|null $body
      * @param ActionInterface[]|null $actions
+     * @param AdaptiveCardExtensionInterface[]|null $extensions
      */
     public static function make(
         Version $version = Version::Version10,
@@ -202,6 +214,7 @@ final class AdaptiveCard implements JsonSerializable
         ?string $speak = null,
         ?string $lang = null,
         ?VerticalContentAlignment $verticalContentAlignment = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $version,
@@ -218,6 +231,7 @@ final class AdaptiveCard implements JsonSerializable
             $speak,
             $lang,
             $verticalContentAlignment,
+            $extensions,
         );
     }
 
@@ -226,6 +240,15 @@ final class AdaptiveCard implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_filter(
             [
                 'type' => self::TYPE,
@@ -244,6 +267,7 @@ final class AdaptiveCard implements JsonSerializable
                 'speak' => $this->speak,
                 'lang' => $this->lang,
                 'verticalContentAlignment' => $this->verticalContentAlignment,
+                ...$extensionProperties,
             ],
             /** @psalm-suppress RedundantConditionGivenDocblockType */
             fn(mixed $value): bool => $value !== null,

--- a/src/AuthCardButton.php
+++ b/src/AuthCardButton.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\AuthCardButtonExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -49,29 +50,43 @@ final class AuthCardButton implements JsonSerializable
     public string $value;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var AuthCardButtonExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "AuthCardButton" instance in a single call
+     *
+     * @param AuthCardButtonExtensionInterface[]|null $extensions
      */
     public function __construct(
         string $value,
         ?string $title = null,
         ?string $image = null,
+        ?array $extensions = null,
     ) {
         $this->value = $value;
         $this->title = $title;
         $this->image = $image;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "AuthCardButton" instance in a single call
      *
      * @psalm-api
+     *
+     * @param AuthCardButtonExtensionInterface[]|null $extensions
      */
     public static function make(
         string $value,
         ?string $title = null,
         ?string $image = null,
+        ?array $extensions = null,
     ): self {
-        return new self($value, $title, $image);
+        return new self($value, $title, $image, $extensions);
     }
 
     /**
@@ -79,12 +94,22 @@ final class AuthCardButton implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_filter(
             [
                 'type' => self::TYPE,
                 'title' => $this->title,
                 'image' => $this->image,
                 'value' => $this->value,
+                ...$extensionProperties,
             ],
             /** @psalm-suppress RedundantConditionGivenDocblockType */
             fn(mixed $value): bool => $value !== null,

--- a/src/Authentication.php
+++ b/src/Authentication.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\AuthenticationExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -59,20 +60,30 @@ final class Authentication implements JsonSerializable
     public ?array $buttons = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var AuthenticationExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "Authentication" instance in a single call
      *
      * @param AuthCardButton[]|null $buttons
+     * @param AuthenticationExtensionInterface[]|null $extensions
      */
     public function __construct(
         ?string $text = null,
         ?string $connectionName = null,
         ?TokenExchangeResource $tokenExchangeResource = null,
         ?array $buttons = null,
+        ?array $extensions = null,
     ) {
         $this->text = $text;
         $this->connectionName = $connectionName;
         $this->tokenExchangeResource = $tokenExchangeResource;
         $this->buttons = $buttons;
+        $this->extensions = $extensions;
     }
 
     /**
@@ -81,18 +92,21 @@ final class Authentication implements JsonSerializable
      * @psalm-api
      *
      * @param AuthCardButton[]|null $buttons
+     * @param AuthenticationExtensionInterface[]|null $extensions
      */
     public static function make(
         ?string $text = null,
         ?string $connectionName = null,
         ?TokenExchangeResource $tokenExchangeResource = null,
         ?array $buttons = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $text,
             $connectionName,
             $tokenExchangeResource,
             $buttons,
+            $extensions,
         );
     }
 
@@ -101,6 +115,15 @@ final class Authentication implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_filter(
             [
                 'type' => self::TYPE,
@@ -108,6 +131,7 @@ final class Authentication implements JsonSerializable
                 'connectionName' => $this->connectionName,
                 'tokenExchangeResource' => $this->tokenExchangeResource,
                 'buttons' => $this->buttons,
+                ...$extensionProperties,
             ],
             /** @psalm-suppress RedundantConditionGivenDocblockType */
             fn(mixed $value): bool => $value !== null,

--- a/src/BackgroundImage.php
+++ b/src/BackgroundImage.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\BackgroundImageExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -55,36 +56,51 @@ final class BackgroundImage implements JsonSerializable
     public ?VerticalAlignment $verticalAlignment = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var BackgroundImageExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "BackgroundImage" instance in a single call
+     *
+     * @param BackgroundImageExtensionInterface[]|null $extensions
      */
     public function __construct(
         string $url,
         ?ImageFillMode $fillMode = null,
         ?HorizontalAlignment $horizontalAlignment = null,
         ?VerticalAlignment $verticalAlignment = null,
+        ?array $extensions = null,
     ) {
         $this->url = $url;
         $this->fillMode = $fillMode;
         $this->horizontalAlignment = $horizontalAlignment;
         $this->verticalAlignment = $verticalAlignment;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "BackgroundImage" instance in a single call
      *
      * @psalm-api
+     *
+     * @param BackgroundImageExtensionInterface[]|null $extensions
      */
     public static function make(
         string $url,
         ?ImageFillMode $fillMode = null,
         ?HorizontalAlignment $horizontalAlignment = null,
         ?VerticalAlignment $verticalAlignment = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $url,
             $fillMode,
             $horizontalAlignment,
             $verticalAlignment,
+            $extensions,
         );
     }
 
@@ -93,6 +109,15 @@ final class BackgroundImage implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_filter(
             [
                 'type' => self::TYPE,
@@ -100,6 +125,7 @@ final class BackgroundImage implements JsonSerializable
                 'fillMode' => $this->fillMode,
                 'horizontalAlignment' => $this->horizontalAlignment,
                 'verticalAlignment' => $this->verticalAlignment,
+                ...$extensionProperties,
             ],
             /** @psalm-suppress RedundantConditionGivenDocblockType */
             fn(mixed $value): bool => $value !== null,

--- a/src/CaptionSource.php
+++ b/src/CaptionSource.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\CaptionSourceExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -48,26 +49,43 @@ final class CaptionSource implements JsonSerializable
     public string $label;
 
     /**
-     * Create a "CaptionSource" instance in a single call
+     * Extensions to augment this element
+     *
+     * @var CaptionSourceExtensionInterface[]|null
      */
-    public function __construct(string $mimeType, string $url, string $label)
-    {
+    public ?array $extensions;
+
+    /**
+     * Create a "CaptionSource" instance in a single call
+     *
+     * @param CaptionSourceExtensionInterface[]|null $extensions
+     */
+    public function __construct(
+        string $mimeType,
+        string $url,
+        string $label,
+        ?array $extensions = null,
+    ) {
         $this->mimeType = $mimeType;
         $this->url = $url;
         $this->label = $label;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "CaptionSource" instance in a single call
      *
      * @psalm-api
+     *
+     * @param CaptionSourceExtensionInterface[]|null $extensions
      */
     public static function make(
         string $mimeType,
         string $url,
         string $label,
+        ?array $extensions = null,
     ): self {
-        return new self($mimeType, $url, $label);
+        return new self($mimeType, $url, $label, $extensions);
     }
 
     /**
@@ -75,12 +93,22 @@ final class CaptionSource implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_filter(
             [
                 'type' => self::TYPE,
                 'mimeType' => $this->mimeType,
                 'url' => $this->url,
                 'label' => $this->label,
+                ...$extensionProperties,
             ],
             /** @psalm-suppress RedundantConditionGivenDocblockType */
             fn(mixed $value): bool => $value !== null,

--- a/src/Column.php
+++ b/src/Column.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\ColumnExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -123,9 +124,17 @@ final class Column extends ToggleableItem implements
     public string|int|null $width = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var ColumnExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "Column" instance in a single call
      *
      * @param ElementInterface[]|null $items
+     * @param ColumnExtensionInterface[]|null $extensions
      */
     public function __construct(
         ?array $items = null,
@@ -142,6 +151,7 @@ final class Column extends ToggleableItem implements
         string|int|null $width = null,
         ?string $id = null,
         ?bool $isVisible = null,
+        ?array $extensions = null,
     ) {
         $this->items = $items;
         $this->backgroundImage = $backgroundImage;
@@ -157,6 +167,7 @@ final class Column extends ToggleableItem implements
         $this->width = $width;
         $this->id = $id;
         $this->isVisible = $isVisible;
+        $this->extensions = $extensions;
     }
 
     /**
@@ -165,6 +176,7 @@ final class Column extends ToggleableItem implements
      * @psalm-api
      *
      * @param ElementInterface[]|null $items
+     * @param ColumnExtensionInterface[]|null $extensions
      */
     public static function make(
         ?array $items = null,
@@ -181,6 +193,7 @@ final class Column extends ToggleableItem implements
         string|int|null $width = null,
         ?string $id = null,
         ?bool $isVisible = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $items,
@@ -197,6 +210,7 @@ final class Column extends ToggleableItem implements
             $width,
             $id,
             $isVisible,
+            $extensions,
         );
     }
 
@@ -205,6 +219,15 @@ final class Column extends ToggleableItem implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
@@ -223,6 +246,7 @@ final class Column extends ToggleableItem implements
                     'verticalContentAlignment' =>
                         $this->verticalContentAlignment,
                     'width' => $this->width,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/ColumnSet.php
+++ b/src/ColumnSet.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\ColumnSetExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -75,9 +76,17 @@ final class ColumnSet extends Element implements
     public ?HorizontalAlignment $horizontalAlignment = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var ColumnSetExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "ColumnSet" instance in a single call
      *
      * @param Column[]|null $columns
+     * @param ColumnSetExtensionInterface[]|null $extensions
      */
     public function __construct(
         ?array $columns = null,
@@ -90,6 +99,7 @@ final class ColumnSet extends Element implements
         ?BlockElementHeight $height = null,
         ?bool $separator = null,
         ?Spacing $spacing = null,
+        ?array $extensions = null,
     ) {
         $this->columns = $columns;
         $this->selectAction = $selectAction;
@@ -101,6 +111,7 @@ final class ColumnSet extends Element implements
         $this->height = $height;
         $this->separator = $separator;
         $this->spacing = $spacing;
+        $this->extensions = $extensions;
     }
 
     /**
@@ -109,6 +120,7 @@ final class ColumnSet extends Element implements
      * @psalm-api
      *
      * @param Column[]|null $columns
+     * @param ColumnSetExtensionInterface[]|null $extensions
      */
     public static function make(
         ?array $columns = null,
@@ -121,6 +133,7 @@ final class ColumnSet extends Element implements
         ?BlockElementHeight $height = null,
         ?bool $separator = null,
         ?Spacing $spacing = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $columns,
@@ -133,6 +146,7 @@ final class ColumnSet extends Element implements
             $height,
             $separator,
             $spacing,
+            $extensions,
         );
     }
 
@@ -141,6 +155,15 @@ final class ColumnSet extends Element implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
@@ -152,6 +175,7 @@ final class ColumnSet extends Element implements
                     'bleed' => $this->bleed,
                     'minHeight' => $this->minHeight,
                     'horizontalAlignment' => $this->horizontalAlignment,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/Container.php
+++ b/src/Container.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\ContainerExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -93,9 +94,17 @@ final class Container extends Element implements
     public ?bool $rtl = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var ContainerExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "Container" instance in a single call
      *
      * @param ElementInterface[] $items
+     * @param ContainerExtensionInterface[]|null $extensions
      */
     public function __construct(
         array $items,
@@ -110,6 +119,7 @@ final class Container extends Element implements
         ?BlockElementHeight $height = null,
         ?bool $separator = null,
         ?Spacing $spacing = null,
+        ?array $extensions = null,
     ) {
         $this->items = $items;
         $this->selectAction = $selectAction;
@@ -123,6 +133,7 @@ final class Container extends Element implements
         $this->height = $height;
         $this->separator = $separator;
         $this->spacing = $spacing;
+        $this->extensions = $extensions;
     }
 
     /**
@@ -131,6 +142,7 @@ final class Container extends Element implements
      * @psalm-api
      *
      * @param ElementInterface[] $items
+     * @param ContainerExtensionInterface[]|null $extensions
      */
     public static function make(
         array $items,
@@ -145,6 +157,7 @@ final class Container extends Element implements
         ?BlockElementHeight $height = null,
         ?bool $separator = null,
         ?Spacing $spacing = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $items,
@@ -159,6 +172,7 @@ final class Container extends Element implements
             $height,
             $separator,
             $spacing,
+            $extensions,
         );
     }
 
@@ -167,6 +181,15 @@ final class Container extends Element implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
@@ -181,6 +204,7 @@ final class Container extends Element implements
                     'backgroundImage' => $this->backgroundImage,
                     'minHeight' => $this->minHeight,
                     'rtl' => $this->rtl,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/Data/Query.php
+++ b/src/Data/Query.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard\Data;
 
+use AdaptiveCard\Extension\Data\QueryExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -51,29 +52,43 @@ final class Query implements JsonSerializable
     public ?int $skip = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var QueryExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "Query" instance in a single call
+     *
+     * @param QueryExtensionInterface[]|null $extensions
      */
     public function __construct(
         string $dataset,
         ?int $count = null,
         ?int $skip = null,
+        ?array $extensions = null,
     ) {
         $this->dataset = $dataset;
         $this->count = $count;
         $this->skip = $skip;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "Query" instance in a single call
      *
      * @psalm-api
+     *
+     * @param QueryExtensionInterface[]|null $extensions
      */
     public static function make(
         string $dataset,
         ?int $count = null,
         ?int $skip = null,
+        ?array $extensions = null,
     ): self {
-        return new self($dataset, $count, $skip);
+        return new self($dataset, $count, $skip, $extensions);
     }
 
     /**
@@ -81,12 +96,22 @@ final class Query implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_filter(
             [
                 'type' => self::TYPE,
                 'dataset' => $this->dataset,
                 'count' => $this->count,
                 'skip' => $this->skip,
+                ...$extensionProperties,
             ],
             /** @psalm-suppress RedundantConditionGivenDocblockType */
             fn(mixed $value): bool => $value !== null,

--- a/src/Extension/Action/ExecuteExtensionInterface.php
+++ b/src/Extension/Action/ExecuteExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension\Action;
+
+interface ExecuteExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/Action/OpenUrlExtensionInterface.php
+++ b/src/Extension/Action/OpenUrlExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension\Action;
+
+interface OpenUrlExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/Action/ShowCardExtensionInterface.php
+++ b/src/Extension/Action/ShowCardExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension\Action;
+
+interface ShowCardExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/Action/SubmitExtensionInterface.php
+++ b/src/Extension/Action/SubmitExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension\Action;
+
+interface SubmitExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/Action/ToggleVisibilityExtensionInterface.php
+++ b/src/Extension/Action/ToggleVisibilityExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension\Action;
+
+interface ToggleVisibilityExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/ActionSetExtensionInterface.php
+++ b/src/Extension/ActionSetExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface ActionSetExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/AdaptiveCardExtensionInterface.php
+++ b/src/Extension/AdaptiveCardExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface AdaptiveCardExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/AuthCardButtonExtensionInterface.php
+++ b/src/Extension/AuthCardButtonExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface AuthCardButtonExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/AuthenticationExtensionInterface.php
+++ b/src/Extension/AuthenticationExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface AuthenticationExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/BackgroundImageExtensionInterface.php
+++ b/src/Extension/BackgroundImageExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface BackgroundImageExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/CaptionSourceExtensionInterface.php
+++ b/src/Extension/CaptionSourceExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface CaptionSourceExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/ColumnExtensionInterface.php
+++ b/src/Extension/ColumnExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface ColumnExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/ColumnSetExtensionInterface.php
+++ b/src/Extension/ColumnSetExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface ColumnSetExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/ContainerExtensionInterface.php
+++ b/src/Extension/ContainerExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface ContainerExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/Data/QueryExtensionInterface.php
+++ b/src/Extension/Data/QueryExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension\Data;
+
+interface QueryExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/FactExtensionInterface.php
+++ b/src/Extension/FactExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface FactExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/FactSetExtensionInterface.php
+++ b/src/Extension/FactSetExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface FactSetExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/ImageExtensionInterface.php
+++ b/src/Extension/ImageExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface ImageExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/ImageSetExtensionInterface.php
+++ b/src/Extension/ImageSetExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface ImageSetExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/Input/ChoiceExtensionInterface.php
+++ b/src/Extension/Input/ChoiceExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension\Input;
+
+interface ChoiceExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/Input/ChoiceSetExtensionInterface.php
+++ b/src/Extension/Input/ChoiceSetExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension\Input;
+
+interface ChoiceSetExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/Input/DateExtensionInterface.php
+++ b/src/Extension/Input/DateExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension\Input;
+
+interface DateExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/Input/NumberExtensionInterface.php
+++ b/src/Extension/Input/NumberExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension\Input;
+
+interface NumberExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/Input/TextExtensionInterface.php
+++ b/src/Extension/Input/TextExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension\Input;
+
+interface TextExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/Input/TimeExtensionInterface.php
+++ b/src/Extension/Input/TimeExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension\Input;
+
+interface TimeExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/Input/ToggleExtensionInterface.php
+++ b/src/Extension/Input/ToggleExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension\Input;
+
+interface ToggleExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/MediaExtensionInterface.php
+++ b/src/Extension/MediaExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface MediaExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/MediaSourceExtensionInterface.php
+++ b/src/Extension/MediaSourceExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface MediaSourceExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/MetadataExtensionInterface.php
+++ b/src/Extension/MetadataExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface MetadataExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/RefreshExtensionInterface.php
+++ b/src/Extension/RefreshExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface RefreshExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/RichTextBlockExtensionInterface.php
+++ b/src/Extension/RichTextBlockExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface RichTextBlockExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/TableCellExtensionInterface.php
+++ b/src/Extension/TableCellExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface TableCellExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/TableColumnDefinitionExtensionInterface.php
+++ b/src/Extension/TableColumnDefinitionExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface TableColumnDefinitionExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/TableExtensionInterface.php
+++ b/src/Extension/TableExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface TableExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/TableRowExtensionInterface.php
+++ b/src/Extension/TableRowExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface TableRowExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/TargetElementExtensionInterface.php
+++ b/src/Extension/TargetElementExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface TargetElementExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/TextBlockExtensionInterface.php
+++ b/src/Extension/TextBlockExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface TextBlockExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/TextRunExtensionInterface.php
+++ b/src/Extension/TextRunExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface TextRunExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Extension/TokenExchangeResourceExtensionInterface.php
+++ b/src/Extension/TokenExchangeResourceExtensionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This is a generated file, do not modify this by hand.
+ */
+
+declare(strict_types=1);
+
+namespace AdaptiveCard\Extension;
+
+interface TokenExchangeResourceExtensionInterface
+{
+    /**
+     * Get additional properties for the extension. These will be merged with the main properties of the class.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensionProperties(): array;
+}

--- a/src/Fact.php
+++ b/src/Fact.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\FactExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -39,22 +40,40 @@ final class Fact implements JsonSerializable
     public string $value;
 
     /**
-     * Create a "Fact" instance in a single call
+     * Extensions to augment this element
+     *
+     * @var FactExtensionInterface[]|null
      */
-    public function __construct(string $title, string $value)
-    {
+    public ?array $extensions;
+
+    /**
+     * Create a "Fact" instance in a single call
+     *
+     * @param FactExtensionInterface[]|null $extensions
+     */
+    public function __construct(
+        string $title,
+        string $value,
+        ?array $extensions = null,
+    ) {
         $this->title = $title;
         $this->value = $value;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "Fact" instance in a single call
      *
      * @psalm-api
+     *
+     * @param FactExtensionInterface[]|null $extensions
      */
-    public static function make(string $title, string $value): self
-    {
-        return new self($title, $value);
+    public static function make(
+        string $title,
+        string $value,
+        ?array $extensions = null,
+    ): self {
+        return new self($title, $value, $extensions);
     }
 
     /**
@@ -62,11 +81,21 @@ final class Fact implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_filter(
             [
                 'type' => self::TYPE,
                 'title' => $this->title,
                 'value' => $this->value,
+                ...$extensionProperties,
             ],
             /** @psalm-suppress RedundantConditionGivenDocblockType */
             fn(mixed $value): bool => $value !== null,

--- a/src/FactSet.php
+++ b/src/FactSet.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\FactSetExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -38,9 +39,17 @@ final class FactSet extends Element implements
     public array $facts;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var FactSetExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "FactSet" instance in a single call
      *
      * @param Fact[] $facts
+     * @param FactSetExtensionInterface[]|null $extensions
      */
     public function __construct(
         array $facts,
@@ -48,12 +57,14 @@ final class FactSet extends Element implements
         ?BlockElementHeight $height = null,
         ?bool $separator = null,
         ?Spacing $spacing = null,
+        ?array $extensions = null,
     ) {
         $this->facts = $facts;
         $this->fallback = $fallback;
         $this->height = $height;
         $this->separator = $separator;
         $this->spacing = $spacing;
+        $this->extensions = $extensions;
     }
 
     /**
@@ -62,6 +73,7 @@ final class FactSet extends Element implements
      * @psalm-api
      *
      * @param Fact[] $facts
+     * @param FactSetExtensionInterface[]|null $extensions
      */
     public static function make(
         array $facts,
@@ -69,8 +81,16 @@ final class FactSet extends Element implements
         ?BlockElementHeight $height = null,
         ?bool $separator = null,
         ?Spacing $spacing = null,
+        ?array $extensions = null,
     ): self {
-        return new self($facts, $fallback, $height, $separator, $spacing);
+        return new self(
+            $facts,
+            $fallback,
+            $height,
+            $separator,
+            $spacing,
+            $extensions,
+        );
     }
 
     /**
@@ -78,12 +98,22 @@ final class FactSet extends Element implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
                 [
                     'type' => self::TYPE,
                     'facts' => $this->facts,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/Image.php
+++ b/src/Image.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\ImageExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -146,7 +147,16 @@ final class Image implements
     public object|array|null $requires = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var ImageExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "Image" instance in a single call
+     *
+     * @param ImageExtensionInterface[]|null $extensions
      */
     public function __construct(
         string $url,
@@ -164,6 +174,7 @@ final class Image implements
         ?string $id = null,
         ?bool $isVisible = null,
         object|array|null $requires = null,
+        ?array $extensions = null,
     ) {
         $this->url = $url;
         $this->altText = $altText;
@@ -180,12 +191,15 @@ final class Image implements
         $this->id = $id;
         $this->isVisible = $isVisible;
         $this->requires = $requires;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "Image" instance in a single call
      *
      * @psalm-api
+     *
+     * @param ImageExtensionInterface[]|null $extensions
      */
     public static function make(
         string $url,
@@ -203,6 +217,7 @@ final class Image implements
         ?string $id = null,
         ?bool $isVisible = null,
         object|array|null $requires = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $url,
@@ -220,6 +235,7 @@ final class Image implements
             $id,
             $isVisible,
             $requires,
+            $extensions,
         );
     }
 
@@ -228,6 +244,15 @@ final class Image implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_filter(
             [
                 'type' => self::TYPE,
@@ -246,6 +271,7 @@ final class Image implements
                 'id' => $this->id,
                 'isVisible' => $this->isVisible,
                 'requires' => $this->requires,
+                ...$extensionProperties,
             ],
             /** @psalm-suppress RedundantConditionGivenDocblockType */
             fn(mixed $value): bool => $value !== null,

--- a/src/ImageSet.php
+++ b/src/ImageSet.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\ImageSetExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -47,9 +48,17 @@ final class ImageSet extends Element implements
     public ?ImageSize $imageSize = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var ImageSetExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "ImageSet" instance in a single call
      *
      * @param Image[] $images
+     * @param ImageSetExtensionInterface[]|null $extensions
      */
     public function __construct(
         array $images,
@@ -58,6 +67,7 @@ final class ImageSet extends Element implements
         ?BlockElementHeight $height = null,
         ?bool $separator = null,
         ?Spacing $spacing = null,
+        ?array $extensions = null,
     ) {
         $this->images = $images;
         $this->imageSize = $imageSize;
@@ -65,6 +75,7 @@ final class ImageSet extends Element implements
         $this->height = $height;
         $this->separator = $separator;
         $this->spacing = $spacing;
+        $this->extensions = $extensions;
     }
 
     /**
@@ -73,6 +84,7 @@ final class ImageSet extends Element implements
      * @psalm-api
      *
      * @param Image[] $images
+     * @param ImageSetExtensionInterface[]|null $extensions
      */
     public static function make(
         array $images,
@@ -81,6 +93,7 @@ final class ImageSet extends Element implements
         ?BlockElementHeight $height = null,
         ?bool $separator = null,
         ?Spacing $spacing = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $images,
@@ -89,6 +102,7 @@ final class ImageSet extends Element implements
             $height,
             $separator,
             $spacing,
+            $extensions,
         );
     }
 
@@ -97,6 +111,15 @@ final class ImageSet extends Element implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
@@ -104,6 +127,7 @@ final class ImageSet extends Element implements
                     'type' => self::TYPE,
                     'images' => $this->images,
                     'imageSize' => $this->imageSize,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/Input/Choice.php
+++ b/src/Input/Choice.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard\Input;
 
+use AdaptiveCard\Extension\Input\ChoiceExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -41,22 +42,40 @@ final class Choice implements JsonSerializable
     public string $value;
 
     /**
-     * Create a "Choice" instance in a single call
+     * Extensions to augment this element
+     *
+     * @var ChoiceExtensionInterface[]|null
      */
-    public function __construct(string $title, string $value)
-    {
+    public ?array $extensions;
+
+    /**
+     * Create a "Choice" instance in a single call
+     *
+     * @param ChoiceExtensionInterface[]|null $extensions
+     */
+    public function __construct(
+        string $title,
+        string $value,
+        ?array $extensions = null,
+    ) {
         $this->title = $title;
         $this->value = $value;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "Choice" instance in a single call
      *
      * @psalm-api
+     *
+     * @param ChoiceExtensionInterface[]|null $extensions
      */
-    public static function make(string $title, string $value): self
-    {
-        return new self($title, $value);
+    public static function make(
+        string $title,
+        string $value,
+        ?array $extensions = null,
+    ): self {
+        return new self($title, $value, $extensions);
     }
 
     /**
@@ -64,11 +83,21 @@ final class Choice implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_filter(
             [
                 'type' => self::TYPE,
                 'title' => $this->title,
                 'value' => $this->value,
+                ...$extensionProperties,
             ],
             /** @psalm-suppress RedundantConditionGivenDocblockType */
             fn(mixed $value): bool => $value !== null,

--- a/src/Input/ChoiceSet.php
+++ b/src/Input/ChoiceSet.php
@@ -11,6 +11,7 @@ namespace AdaptiveCard\Input;
 use AdaptiveCard\ChoiceInputStyle;
 use AdaptiveCard\Data\Query;
 use AdaptiveCard\ElementInterface;
+use AdaptiveCard\Extension\Input\ChoiceSetExtensionInterface;
 use AdaptiveCard\Input;
 use AdaptiveCard\InputInterface;
 use AdaptiveCard\ItemInterface;
@@ -86,9 +87,17 @@ final class ChoiceSet extends Input implements
     public ?bool $wrap = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var ChoiceSetExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "ChoiceSet" instance in a single call
      *
      * @param Input\Choice[]|null $choices
+     * @param ChoiceSetExtensionInterface[]|null $extensions
      */
     public function __construct(
         string $id,
@@ -111,6 +120,7 @@ final class ChoiceSet extends Input implements
         ?\AdaptiveCard\Spacing $spacing = null,
         ?bool $isVisible = null,
         object|array|null $requires = null,
+        ?array $extensions = null,
     ) {
         $this->id = $id;
         $this->choices = $choices;
@@ -132,6 +142,7 @@ final class ChoiceSet extends Input implements
         $this->spacing = $spacing;
         $this->isVisible = $isVisible;
         $this->requires = $requires;
+        $this->extensions = $extensions;
     }
 
     /**
@@ -140,6 +151,7 @@ final class ChoiceSet extends Input implements
      * @psalm-api
      *
      * @param Input\Choice[]|null $choices
+     * @param ChoiceSetExtensionInterface[]|null $extensions
      */
     public static function make(
         string $id,
@@ -162,6 +174,7 @@ final class ChoiceSet extends Input implements
         ?\AdaptiveCard\Spacing $spacing = null,
         ?bool $isVisible = null,
         object|array|null $requires = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $id,
@@ -184,6 +197,7 @@ final class ChoiceSet extends Input implements
             $spacing,
             $isVisible,
             $requires,
+            $extensions,
         );
     }
 
@@ -192,6 +206,15 @@ final class ChoiceSet extends Input implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
@@ -204,6 +227,7 @@ final class ChoiceSet extends Input implements
                     'value' => $this->value,
                     'placeholder' => $this->placeholder,
                     'wrap' => $this->wrap,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/Input/Date.php
+++ b/src/Input/Date.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace AdaptiveCard\Input;
 
 use AdaptiveCard\ElementInterface;
+use AdaptiveCard\Extension\Input\DateExtensionInterface;
 use AdaptiveCard\Input;
 use AdaptiveCard\InputInterface;
 use AdaptiveCard\ItemInterface;
@@ -63,7 +64,16 @@ final class Date extends Input implements
     public ?string $value = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var DateExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "Date" instance in a single call
+     *
+     * @param DateExtensionInterface[]|null $extensions
      */
     public function __construct(
         string $id,
@@ -83,6 +93,7 @@ final class Date extends Input implements
         ?\AdaptiveCard\Spacing $spacing = null,
         ?bool $isVisible = null,
         object|array|null $requires = null,
+        ?array $extensions = null,
     ) {
         $this->id = $id;
         $this->max = $max;
@@ -101,12 +112,15 @@ final class Date extends Input implements
         $this->spacing = $spacing;
         $this->isVisible = $isVisible;
         $this->requires = $requires;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "Date" instance in a single call
      *
      * @psalm-api
+     *
+     * @param DateExtensionInterface[]|null $extensions
      */
     public static function make(
         string $id,
@@ -126,6 +140,7 @@ final class Date extends Input implements
         ?\AdaptiveCard\Spacing $spacing = null,
         ?bool $isVisible = null,
         object|array|null $requires = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $id,
@@ -145,6 +160,7 @@ final class Date extends Input implements
             $spacing,
             $isVisible,
             $requires,
+            $extensions,
         );
     }
 
@@ -153,6 +169,15 @@ final class Date extends Input implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
@@ -162,6 +187,7 @@ final class Date extends Input implements
                     'min' => $this->min,
                     'placeholder' => $this->placeholder,
                     'value' => $this->value,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/Input/Number.php
+++ b/src/Input/Number.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace AdaptiveCard\Input;
 
 use AdaptiveCard\ElementInterface;
+use AdaptiveCard\Extension\Input\NumberExtensionInterface;
 use AdaptiveCard\Input;
 use AdaptiveCard\InputInterface;
 use AdaptiveCard\ItemInterface;
@@ -63,7 +64,16 @@ final class Number extends Input implements
     public ?int $value = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var NumberExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "Number" instance in a single call
+     *
+     * @param NumberExtensionInterface[]|null $extensions
      */
     public function __construct(
         string $id,
@@ -83,6 +93,7 @@ final class Number extends Input implements
         ?\AdaptiveCard\Spacing $spacing = null,
         ?bool $isVisible = null,
         object|array|null $requires = null,
+        ?array $extensions = null,
     ) {
         $this->id = $id;
         $this->max = $max;
@@ -101,12 +112,15 @@ final class Number extends Input implements
         $this->spacing = $spacing;
         $this->isVisible = $isVisible;
         $this->requires = $requires;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "Number" instance in a single call
      *
      * @psalm-api
+     *
+     * @param NumberExtensionInterface[]|null $extensions
      */
     public static function make(
         string $id,
@@ -126,6 +140,7 @@ final class Number extends Input implements
         ?\AdaptiveCard\Spacing $spacing = null,
         ?bool $isVisible = null,
         object|array|null $requires = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $id,
@@ -145,6 +160,7 @@ final class Number extends Input implements
             $spacing,
             $isVisible,
             $requires,
+            $extensions,
         );
     }
 
@@ -153,6 +169,15 @@ final class Number extends Input implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
@@ -162,6 +187,7 @@ final class Number extends Input implements
                     'min' => $this->min,
                     'placeholder' => $this->placeholder,
                     'value' => $this->value,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/Input/Text.php
+++ b/src/Input/Text.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace AdaptiveCard\Input;
 
 use AdaptiveCard\ElementInterface;
+use AdaptiveCard\Extension\Input\TextExtensionInterface;
 use AdaptiveCard\ISelectActionInterface;
 use AdaptiveCard\Input;
 use AdaptiveCard\InputInterface;
@@ -88,7 +89,16 @@ final class Text extends Input implements
     public ?string $value = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var TextExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "Text" instance in a single call
+     *
+     * @param TextExtensionInterface[]|null $extensions
      */
     public function __construct(
         string $id,
@@ -111,6 +121,7 @@ final class Text extends Input implements
         ?\AdaptiveCard\Spacing $spacing = null,
         ?bool $isVisible = null,
         object|array|null $requires = null,
+        ?array $extensions = null,
     ) {
         $this->id = $id;
         $this->isMultiline = $isMultiline;
@@ -132,12 +143,15 @@ final class Text extends Input implements
         $this->spacing = $spacing;
         $this->isVisible = $isVisible;
         $this->requires = $requires;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "Text" instance in a single call
      *
      * @psalm-api
+     *
+     * @param TextExtensionInterface[]|null $extensions
      */
     public static function make(
         string $id,
@@ -160,6 +174,7 @@ final class Text extends Input implements
         ?\AdaptiveCard\Spacing $spacing = null,
         ?bool $isVisible = null,
         object|array|null $requires = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $id,
@@ -182,6 +197,7 @@ final class Text extends Input implements
             $spacing,
             $isVisible,
             $requires,
+            $extensions,
         );
     }
 
@@ -190,6 +206,15 @@ final class Text extends Input implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
@@ -202,6 +227,7 @@ final class Text extends Input implements
                     'style' => $this->style,
                     'inlineAction' => $this->inlineAction,
                     'value' => $this->value,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/Input/Time.php
+++ b/src/Input/Time.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace AdaptiveCard\Input;
 
 use AdaptiveCard\ElementInterface;
+use AdaptiveCard\Extension\Input\TimeExtensionInterface;
 use AdaptiveCard\Input;
 use AdaptiveCard\InputInterface;
 use AdaptiveCard\ItemInterface;
@@ -63,7 +64,16 @@ final class Time extends Input implements
     public ?string $value = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var TimeExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "Time" instance in a single call
+     *
+     * @param TimeExtensionInterface[]|null $extensions
      */
     public function __construct(
         string $id,
@@ -83,6 +93,7 @@ final class Time extends Input implements
         ?\AdaptiveCard\Spacing $spacing = null,
         ?bool $isVisible = null,
         object|array|null $requires = null,
+        ?array $extensions = null,
     ) {
         $this->id = $id;
         $this->max = $max;
@@ -101,12 +112,15 @@ final class Time extends Input implements
         $this->spacing = $spacing;
         $this->isVisible = $isVisible;
         $this->requires = $requires;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "Time" instance in a single call
      *
      * @psalm-api
+     *
+     * @param TimeExtensionInterface[]|null $extensions
      */
     public static function make(
         string $id,
@@ -126,6 +140,7 @@ final class Time extends Input implements
         ?\AdaptiveCard\Spacing $spacing = null,
         ?bool $isVisible = null,
         object|array|null $requires = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $id,
@@ -145,6 +160,7 @@ final class Time extends Input implements
             $spacing,
             $isVisible,
             $requires,
+            $extensions,
         );
     }
 
@@ -153,6 +169,15 @@ final class Time extends Input implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
@@ -162,6 +187,7 @@ final class Time extends Input implements
                     'min' => $this->min,
                     'placeholder' => $this->placeholder,
                     'value' => $this->value,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/Input/Toggle.php
+++ b/src/Input/Toggle.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace AdaptiveCard\Input;
 
 use AdaptiveCard\ElementInterface;
+use AdaptiveCard\Extension\Input\ToggleExtensionInterface;
 use AdaptiveCard\Input;
 use AdaptiveCard\InputInterface;
 use AdaptiveCard\ItemInterface;
@@ -71,7 +72,16 @@ final class Toggle extends Input implements
     public ?bool $wrap = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var ToggleExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "Toggle" instance in a single call
+     *
+     * @param ToggleExtensionInterface[]|null $extensions
      */
     public function __construct(
         string $title,
@@ -92,6 +102,7 @@ final class Toggle extends Input implements
         ?\AdaptiveCard\Spacing $spacing = null,
         ?bool $isVisible = null,
         object|array|null $requires = null,
+        ?array $extensions = null,
     ) {
         $this->title = $title;
         $this->id = $id;
@@ -111,12 +122,15 @@ final class Toggle extends Input implements
         $this->spacing = $spacing;
         $this->isVisible = $isVisible;
         $this->requires = $requires;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "Toggle" instance in a single call
      *
      * @psalm-api
+     *
+     * @param ToggleExtensionInterface[]|null $extensions
      */
     public static function make(
         string $title,
@@ -137,6 +151,7 @@ final class Toggle extends Input implements
         ?\AdaptiveCard\Spacing $spacing = null,
         ?bool $isVisible = null,
         object|array|null $requires = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $title,
@@ -157,6 +172,7 @@ final class Toggle extends Input implements
             $spacing,
             $isVisible,
             $requires,
+            $extensions,
         );
     }
 
@@ -165,6 +181,15 @@ final class Toggle extends Input implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
@@ -175,6 +200,7 @@ final class Toggle extends Input implements
                     'valueOff' => $this->valueOff,
                     'valueOn' => $this->valueOn,
                     'wrap' => $this->wrap,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/Media.php
+++ b/src/Media.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\MediaExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -63,10 +64,18 @@ final class Media extends Element implements
     public ?array $captionSources = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var MediaExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "Media" instance in a single call
      *
      * @param MediaSource[] $sources
      * @param CaptionSource[]|null $captionSources
+     * @param MediaExtensionInterface[]|null $extensions
      */
     public function __construct(
         array $sources,
@@ -77,6 +86,7 @@ final class Media extends Element implements
         ?BlockElementHeight $height = null,
         ?bool $separator = null,
         ?Spacing $spacing = null,
+        ?array $extensions = null,
     ) {
         $this->sources = $sources;
         $this->poster = $poster;
@@ -86,6 +96,7 @@ final class Media extends Element implements
         $this->height = $height;
         $this->separator = $separator;
         $this->spacing = $spacing;
+        $this->extensions = $extensions;
     }
 
     /**
@@ -95,6 +106,7 @@ final class Media extends Element implements
      *
      * @param MediaSource[] $sources
      * @param CaptionSource[]|null $captionSources
+     * @param MediaExtensionInterface[]|null $extensions
      */
     public static function make(
         array $sources,
@@ -105,6 +117,7 @@ final class Media extends Element implements
         ?BlockElementHeight $height = null,
         ?bool $separator = null,
         ?Spacing $spacing = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $sources,
@@ -115,6 +128,7 @@ final class Media extends Element implements
             $height,
             $separator,
             $spacing,
+            $extensions,
         );
     }
 
@@ -123,6 +137,15 @@ final class Media extends Element implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
@@ -132,6 +155,7 @@ final class Media extends Element implements
                     'poster' => $this->poster,
                     'altText' => $this->altText,
                     'captionSources' => $this->captionSources,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/MediaSource.php
+++ b/src/MediaSource.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\MediaSourceExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -40,22 +41,40 @@ final class MediaSource implements JsonSerializable
     public string $url;
 
     /**
-     * Create a "MediaSource" instance in a single call
+     * Extensions to augment this element
+     *
+     * @var MediaSourceExtensionInterface[]|null
      */
-    public function __construct(string $url, ?string $mimeType = null)
-    {
+    public ?array $extensions;
+
+    /**
+     * Create a "MediaSource" instance in a single call
+     *
+     * @param MediaSourceExtensionInterface[]|null $extensions
+     */
+    public function __construct(
+        string $url,
+        ?string $mimeType = null,
+        ?array $extensions = null,
+    ) {
         $this->url = $url;
         $this->mimeType = $mimeType;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "MediaSource" instance in a single call
      *
      * @psalm-api
+     *
+     * @param MediaSourceExtensionInterface[]|null $extensions
      */
-    public static function make(string $url, ?string $mimeType = null): self
-    {
-        return new self($url, $mimeType);
+    public static function make(
+        string $url,
+        ?string $mimeType = null,
+        ?array $extensions = null,
+    ): self {
+        return new self($url, $mimeType, $extensions);
     }
 
     /**
@@ -63,11 +82,21 @@ final class MediaSource implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_filter(
             [
                 'type' => self::TYPE,
                 'mimeType' => $this->mimeType,
                 'url' => $this->url,
+                ...$extensionProperties,
             ],
             /** @psalm-suppress RedundantConditionGivenDocblockType */
             fn(mixed $value): bool => $value !== null,

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\MetadataExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -33,21 +34,37 @@ final class Metadata implements JsonSerializable
     public ?string $webUrl = null;
 
     /**
-     * Create a "Metadata" instance in a single call
+     * Extensions to augment this element
+     *
+     * @var MetadataExtensionInterface[]|null
      */
-    public function __construct(?string $webUrl = null)
-    {
+    public ?array $extensions;
+
+    /**
+     * Create a "Metadata" instance in a single call
+     *
+     * @param MetadataExtensionInterface[]|null $extensions
+     */
+    public function __construct(
+        ?string $webUrl = null,
+        ?array $extensions = null,
+    ) {
         $this->webUrl = $webUrl;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "Metadata" instance in a single call
      *
      * @psalm-api
+     *
+     * @param MetadataExtensionInterface[]|null $extensions
      */
-    public static function make(?string $webUrl = null): self
-    {
-        return new self($webUrl);
+    public static function make(
+        ?string $webUrl = null,
+        ?array $extensions = null,
+    ): self {
+        return new self($webUrl, $extensions);
     }
 
     /**
@@ -55,10 +72,20 @@ final class Metadata implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_filter(
             [
                 'type' => self::TYPE,
                 'webUrl' => $this->webUrl,
+                ...$extensionProperties,
             ],
             /** @psalm-suppress RedundantConditionGivenDocblockType */
             fn(mixed $value): bool => $value !== null,

--- a/src/Refresh.php
+++ b/src/Refresh.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace AdaptiveCard;
 
 use AdaptiveCard\Action\Execute;
+use AdaptiveCard\Extension\RefreshExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -55,18 +56,28 @@ final class Refresh implements JsonSerializable
     public ?array $userIds = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var RefreshExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "Refresh" instance in a single call
      *
      * @param string[]|null $userIds
+     * @param RefreshExtensionInterface[]|null $extensions
      */
     public function __construct(
         ?Execute $action = null,
         ?string $expires = null,
         ?array $userIds = null,
+        ?array $extensions = null,
     ) {
         $this->action = $action;
         $this->expires = $expires;
         $this->userIds = $userIds;
+        $this->extensions = $extensions;
     }
 
     /**
@@ -75,13 +86,15 @@ final class Refresh implements JsonSerializable
      * @psalm-api
      *
      * @param string[]|null $userIds
+     * @param RefreshExtensionInterface[]|null $extensions
      */
     public static function make(
         ?Execute $action = null,
         ?string $expires = null,
         ?array $userIds = null,
+        ?array $extensions = null,
     ): self {
-        return new self($action, $expires, $userIds);
+        return new self($action, $expires, $userIds, $extensions);
     }
 
     /**
@@ -89,12 +102,22 @@ final class Refresh implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_filter(
             [
                 'type' => self::TYPE,
                 'action' => $this->action,
                 'expires' => $this->expires,
                 'userIds' => $this->userIds,
+                ...$extensionProperties,
             ],
             /** @psalm-suppress RedundantConditionGivenDocblockType */
             fn(mixed $value): bool => $value !== null,

--- a/src/RichTextBlock.php
+++ b/src/RichTextBlock.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\RichTextBlockExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -46,9 +47,17 @@ final class RichTextBlock extends Element implements
     public ?HorizontalAlignment $horizontalAlignment = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var RichTextBlockExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "RichTextBlock" instance in a single call
      *
      * @param InlineInterface[] $inlines
+     * @param RichTextBlockExtensionInterface[]|null $extensions
      */
     public function __construct(
         array $inlines,
@@ -57,6 +66,7 @@ final class RichTextBlock extends Element implements
         ?BlockElementHeight $height = null,
         ?bool $separator = null,
         ?Spacing $spacing = null,
+        ?array $extensions = null,
     ) {
         $this->inlines = $inlines;
         $this->horizontalAlignment = $horizontalAlignment;
@@ -64,6 +74,7 @@ final class RichTextBlock extends Element implements
         $this->height = $height;
         $this->separator = $separator;
         $this->spacing = $spacing;
+        $this->extensions = $extensions;
     }
 
     /**
@@ -72,6 +83,7 @@ final class RichTextBlock extends Element implements
      * @psalm-api
      *
      * @param InlineInterface[] $inlines
+     * @param RichTextBlockExtensionInterface[]|null $extensions
      */
     public static function make(
         array $inlines,
@@ -80,6 +92,7 @@ final class RichTextBlock extends Element implements
         ?BlockElementHeight $height = null,
         ?bool $separator = null,
         ?Spacing $spacing = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $inlines,
@@ -88,6 +101,7 @@ final class RichTextBlock extends Element implements
             $height,
             $separator,
             $spacing,
+            $extensions,
         );
     }
 
@@ -96,6 +110,15 @@ final class RichTextBlock extends Element implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
@@ -103,6 +126,7 @@ final class RichTextBlock extends Element implements
                     'type' => self::TYPE,
                     'inlines' => $this->inlines,
                     'horizontalAlignment' => $this->horizontalAlignment,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/Table.php
+++ b/src/Table.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\TableExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -84,10 +85,18 @@ final class Table extends Element implements
     public ?VerticalAlignment $verticalCellContentAlignment = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var TableExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "Table" instance in a single call
      *
      * @param TableColumnDefinition[]|null $columns
      * @param TableRow[]|null $rows
+     * @param TableExtensionInterface[]|null $extensions
      */
     public function __construct(
         ?array $columns = null,
@@ -101,6 +110,7 @@ final class Table extends Element implements
         ?BlockElementHeight $height = null,
         ?bool $separator = null,
         ?Spacing $spacing = null,
+        ?array $extensions = null,
     ) {
         $this->columns = $columns;
         $this->rows = $rows;
@@ -113,6 +123,7 @@ final class Table extends Element implements
         $this->height = $height;
         $this->separator = $separator;
         $this->spacing = $spacing;
+        $this->extensions = $extensions;
     }
 
     /**
@@ -122,6 +133,7 @@ final class Table extends Element implements
      *
      * @param TableColumnDefinition[]|null $columns
      * @param TableRow[]|null $rows
+     * @param TableExtensionInterface[]|null $extensions
      */
     public static function make(
         ?array $columns = null,
@@ -135,6 +147,7 @@ final class Table extends Element implements
         ?BlockElementHeight $height = null,
         ?bool $separator = null,
         ?Spacing $spacing = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $columns,
@@ -148,6 +161,7 @@ final class Table extends Element implements
             $height,
             $separator,
             $spacing,
+            $extensions,
         );
     }
 
@@ -156,6 +170,15 @@ final class Table extends Element implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
@@ -170,6 +193,7 @@ final class Table extends Element implements
                         $this->horizontalCellContentAlignment,
                     'verticalCellContentAlignment' =>
                         $this->verticalCellContentAlignment,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/TableCell.php
+++ b/src/TableCell.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\TableCellExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -89,9 +90,17 @@ final class TableCell implements JsonSerializable
     public ?bool $rtl = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var TableCellExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "TableCell" instance in a single call
      *
      * @param ElementInterface[] $items
+     * @param TableCellExtensionInterface[]|null $extensions
      */
     public function __construct(
         array $items,
@@ -102,6 +111,7 @@ final class TableCell implements JsonSerializable
         BackgroundImage|string|null $backgroundImage = null,
         ?string $minHeight = null,
         ?bool $rtl = null,
+        ?array $extensions = null,
     ) {
         $this->items = $items;
         $this->selectAction = $selectAction;
@@ -111,6 +121,7 @@ final class TableCell implements JsonSerializable
         $this->backgroundImage = $backgroundImage;
         $this->minHeight = $minHeight;
         $this->rtl = $rtl;
+        $this->extensions = $extensions;
     }
 
     /**
@@ -119,6 +130,7 @@ final class TableCell implements JsonSerializable
      * @psalm-api
      *
      * @param ElementInterface[] $items
+     * @param TableCellExtensionInterface[]|null $extensions
      */
     public static function make(
         array $items,
@@ -129,6 +141,7 @@ final class TableCell implements JsonSerializable
         BackgroundImage|string|null $backgroundImage = null,
         ?string $minHeight = null,
         ?bool $rtl = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $items,
@@ -139,6 +152,7 @@ final class TableCell implements JsonSerializable
             $backgroundImage,
             $minHeight,
             $rtl,
+            $extensions,
         );
     }
 
@@ -147,6 +161,15 @@ final class TableCell implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_filter(
             [
                 'type' => self::TYPE,
@@ -158,6 +181,7 @@ final class TableCell implements JsonSerializable
                 'backgroundImage' => $this->backgroundImage,
                 'minHeight' => $this->minHeight,
                 'rtl' => $this->rtl,
+                ...$extensionProperties,
             ],
             /** @psalm-suppress RedundantConditionGivenDocblockType */
             fn(mixed $value): bool => $value !== null,

--- a/src/TableColumnDefinition.php
+++ b/src/TableColumnDefinition.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\TableColumnDefinitionExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -55,32 +56,47 @@ final class TableColumnDefinition implements JsonSerializable
     public ?VerticalAlignment $verticalCellContentAlignment = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var TableColumnDefinitionExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "TableColumnDefinition" instance in a single call
+     *
+     * @param TableColumnDefinitionExtensionInterface[]|null $extensions
      */
     public function __construct(
         string|int|null $width = null,
         ?HorizontalAlignment $horizontalCellContentAlignment = null,
         ?VerticalAlignment $verticalCellContentAlignment = null,
+        ?array $extensions = null,
     ) {
         $this->width = $width;
         $this->horizontalCellContentAlignment = $horizontalCellContentAlignment;
         $this->verticalCellContentAlignment = $verticalCellContentAlignment;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "TableColumnDefinition" instance in a single call
      *
      * @psalm-api
+     *
+     * @param TableColumnDefinitionExtensionInterface[]|null $extensions
      */
     public static function make(
         string|int|null $width = null,
         ?HorizontalAlignment $horizontalCellContentAlignment = null,
         ?VerticalAlignment $verticalCellContentAlignment = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $width,
             $horizontalCellContentAlignment,
             $verticalCellContentAlignment,
+            $extensions,
         );
     }
 
@@ -89,6 +105,15 @@ final class TableColumnDefinition implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_filter(
             [
                 'type' => self::TYPE,
@@ -97,6 +122,7 @@ final class TableColumnDefinition implements JsonSerializable
                     $this->horizontalCellContentAlignment,
                 'verticalCellContentAlignment' =>
                     $this->verticalCellContentAlignment,
+                ...$extensionProperties,
             ],
             /** @psalm-suppress RedundantConditionGivenDocblockType */
             fn(mixed $value): bool => $value !== null,

--- a/src/TableRow.php
+++ b/src/TableRow.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\TableRowExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -61,20 +62,30 @@ final class TableRow implements JsonSerializable
     public ?VerticalAlignment $verticalCellContentAlignment = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var TableRowExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "TableRow" instance in a single call
      *
      * @param TableCell[]|null $cells
+     * @param TableRowExtensionInterface[]|null $extensions
      */
     public function __construct(
         ?array $cells = null,
         ?ContainerStyle $style = null,
         ?HorizontalAlignment $horizontalCellContentAlignment = null,
         ?VerticalAlignment $verticalCellContentAlignment = null,
+        ?array $extensions = null,
     ) {
         $this->cells = $cells;
         $this->style = $style;
         $this->horizontalCellContentAlignment = $horizontalCellContentAlignment;
         $this->verticalCellContentAlignment = $verticalCellContentAlignment;
+        $this->extensions = $extensions;
     }
 
     /**
@@ -83,18 +94,21 @@ final class TableRow implements JsonSerializable
      * @psalm-api
      *
      * @param TableCell[]|null $cells
+     * @param TableRowExtensionInterface[]|null $extensions
      */
     public static function make(
         ?array $cells = null,
         ?ContainerStyle $style = null,
         ?HorizontalAlignment $horizontalCellContentAlignment = null,
         ?VerticalAlignment $verticalCellContentAlignment = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $cells,
             $style,
             $horizontalCellContentAlignment,
             $verticalCellContentAlignment,
+            $extensions,
         );
     }
 
@@ -103,6 +117,15 @@ final class TableRow implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_filter(
             [
                 'type' => self::TYPE,
@@ -112,6 +135,7 @@ final class TableRow implements JsonSerializable
                     $this->horizontalCellContentAlignment,
                 'verticalCellContentAlignment' =>
                     $this->verticalCellContentAlignment,
+                ...$extensionProperties,
             ],
             /** @psalm-suppress RedundantConditionGivenDocblockType */
             fn(mixed $value): bool => $value !== null,

--- a/src/TargetElement.php
+++ b/src/TargetElement.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\TargetElementExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -40,24 +41,40 @@ final class TargetElement implements JsonSerializable
     public ?bool $isVisible = null;
 
     /**
-     * Create a "TargetElement" instance in a single call
+     * Extensions to augment this element
+     *
+     * @var TargetElementExtensionInterface[]|null
      */
-    public function __construct(string $elementId, ?bool $isVisible = null)
-    {
+    public ?array $extensions;
+
+    /**
+     * Create a "TargetElement" instance in a single call
+     *
+     * @param TargetElementExtensionInterface[]|null $extensions
+     */
+    public function __construct(
+        string $elementId,
+        ?bool $isVisible = null,
+        ?array $extensions = null,
+    ) {
         $this->elementId = $elementId;
         $this->isVisible = $isVisible;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "TargetElement" instance in a single call
      *
      * @psalm-api
+     *
+     * @param TargetElementExtensionInterface[]|null $extensions
      */
     public static function make(
         string $elementId,
         ?bool $isVisible = null,
+        ?array $extensions = null,
     ): self {
-        return new self($elementId, $isVisible);
+        return new self($elementId, $isVisible, $extensions);
     }
 
     /**
@@ -65,11 +82,21 @@ final class TargetElement implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_filter(
             [
                 'type' => self::TYPE,
                 'elementId' => $this->elementId,
                 'isVisible' => $this->isVisible,
+                ...$extensionProperties,
             ],
             /** @psalm-suppress RedundantConditionGivenDocblockType */
             fn(mixed $value): bool => $value !== null,

--- a/src/TextBlock.php
+++ b/src/TextBlock.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\TextBlockExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -102,7 +103,16 @@ final class TextBlock extends Element implements
     public ?TextBlockStyle $style = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var TextBlockExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "TextBlock" instance in a single call
+     *
+     * @param TextBlockExtensionInterface[]|null $extensions
      */
     public function __construct(
         string $text,
@@ -119,6 +129,7 @@ final class TextBlock extends Element implements
         ?BlockElementHeight $height = null,
         ?bool $separator = null,
         ?Spacing $spacing = null,
+        ?array $extensions = null,
     ) {
         $this->text = $text;
         $this->color = $color;
@@ -134,12 +145,15 @@ final class TextBlock extends Element implements
         $this->height = $height;
         $this->separator = $separator;
         $this->spacing = $spacing;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "TextBlock" instance in a single call
      *
      * @psalm-api
+     *
+     * @param TextBlockExtensionInterface[]|null $extensions
      */
     public static function make(
         string $text,
@@ -156,6 +170,7 @@ final class TextBlock extends Element implements
         ?BlockElementHeight $height = null,
         ?bool $separator = null,
         ?Spacing $spacing = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $text,
@@ -172,6 +187,7 @@ final class TextBlock extends Element implements
             $height,
             $separator,
             $spacing,
+            $extensions,
         );
     }
 
@@ -180,6 +196,15 @@ final class TextBlock extends Element implements
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_merge(
             parent::jsonSerialize(),
             array_filter(
@@ -195,6 +220,7 @@ final class TextBlock extends Element implements
                     'weight' => $this->weight,
                     'wrap' => $this->wrap,
                     'style' => $this->style,
+                    ...$extensionProperties,
                 ],
                 /** @psalm-suppress RedundantConditionGivenDocblockType */
                 fn(mixed $value): bool => $value !== null,

--- a/src/TextRun.php
+++ b/src/TextRun.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\TextRunExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -105,7 +106,16 @@ final class TextRun implements JsonSerializable, InlineInterface
     public ?FontWeight $weight = null;
 
     /**
+     * Extensions to augment this element
+     *
+     * @var TextRunExtensionInterface[]|null
+     */
+    public ?array $extensions;
+
+    /**
      * Create a "TextRun" instance in a single call
+     *
+     * @param TextRunExtensionInterface[]|null $extensions
      */
     public function __construct(
         string $text,
@@ -119,6 +129,7 @@ final class TextRun implements JsonSerializable, InlineInterface
         ?bool $strikethrough = null,
         ?bool $underline = null,
         ?FontWeight $weight = null,
+        ?array $extensions = null,
     ) {
         $this->text = $text;
         $this->color = $color;
@@ -131,12 +142,15 @@ final class TextRun implements JsonSerializable, InlineInterface
         $this->strikethrough = $strikethrough;
         $this->underline = $underline;
         $this->weight = $weight;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "TextRun" instance in a single call
      *
      * @psalm-api
+     *
+     * @param TextRunExtensionInterface[]|null $extensions
      */
     public static function make(
         string $text,
@@ -150,6 +164,7 @@ final class TextRun implements JsonSerializable, InlineInterface
         ?bool $strikethrough = null,
         ?bool $underline = null,
         ?FontWeight $weight = null,
+        ?array $extensions = null,
     ): self {
         return new self(
             $text,
@@ -163,6 +178,7 @@ final class TextRun implements JsonSerializable, InlineInterface
             $strikethrough,
             $underline,
             $weight,
+            $extensions,
         );
     }
 
@@ -171,6 +187,15 @@ final class TextRun implements JsonSerializable, InlineInterface
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_filter(
             [
                 'type' => self::TYPE,
@@ -185,6 +210,7 @@ final class TextRun implements JsonSerializable, InlineInterface
                 'strikethrough' => $this->strikethrough,
                 'underline' => $this->underline,
                 'weight' => $this->weight,
+                ...$extensionProperties,
             ],
             /** @psalm-suppress RedundantConditionGivenDocblockType */
             fn(mixed $value): bool => $value !== null,

--- a/src/TokenExchangeResource.php
+++ b/src/TokenExchangeResource.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace AdaptiveCard;
 
+use AdaptiveCard\Extension\TokenExchangeResourceExtensionInterface;
 use JsonSerializable;
 
 /**
@@ -50,26 +51,43 @@ final class TokenExchangeResource implements JsonSerializable
     public string $providerId;
 
     /**
-     * Create a "TokenExchangeResource" instance in a single call
+     * Extensions to augment this element
+     *
+     * @var TokenExchangeResourceExtensionInterface[]|null
      */
-    public function __construct(string $id, string $uri, string $providerId)
-    {
+    public ?array $extensions;
+
+    /**
+     * Create a "TokenExchangeResource" instance in a single call
+     *
+     * @param TokenExchangeResourceExtensionInterface[]|null $extensions
+     */
+    public function __construct(
+        string $id,
+        string $uri,
+        string $providerId,
+        ?array $extensions = null,
+    ) {
         $this->id = $id;
         $this->uri = $uri;
         $this->providerId = $providerId;
+        $this->extensions = $extensions;
     }
 
     /**
      * Make a "TokenExchangeResource" instance in a single call
      *
      * @psalm-api
+     *
+     * @param TokenExchangeResourceExtensionInterface[]|null $extensions
      */
     public static function make(
         string $id,
         string $uri,
         string $providerId,
+        ?array $extensions = null,
     ): self {
-        return new self($id, $uri, $providerId);
+        return new self($id, $uri, $providerId, $extensions);
     }
 
     /**
@@ -77,12 +95,22 @@ final class TokenExchangeResource implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $extensionProperties = [];
+
+        foreach ($this->extensions ?? [] as $extension) {
+            $extensionProperties = array_merge_recursive(
+                $extensionProperties,
+                $extension->getExtensionProperties(),
+            );
+        }
+
         return array_filter(
             [
                 'type' => self::TYPE,
                 'id' => $this->id,
                 'uri' => $this->uri,
                 'providerId' => $this->providerId,
+                ...$extensionProperties,
             ],
             /** @psalm-suppress RedundantConditionGivenDocblockType */
             fn(mixed $value): bool => $value !== null,

--- a/tests/AdaptiveCardExtensionTest.php
+++ b/tests/AdaptiveCardExtensionTest.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdaptiveCardTests;
+
+use AdaptiveCard\AdaptiveCard;
+use AdaptiveCard\Image;
+use AdaptiveCard\ImageSize;
+use AdaptiveCard\ImageStyle;
+use AdaptiveCard\TextBlock;
+use AdaptiveCardExtension\MicrosoftTeams\AllowExpand;
+use AdaptiveCardExtension\MicrosoftTeams\FullWidth;
+use AdaptiveCardExtension\MicrosoftTeams\Mention;
+use PHPUnit\Framework\TestCase;
+
+final class AdaptiveCardExtensionTest extends TestCase
+{
+    /**
+     * @covers AdaptiveCard
+     * @covers FullWidth
+     */
+    public function testEmptyCardFullWidth(): void
+    {
+        $card = new AdaptiveCard(extensions: [new FullWidth()]);
+
+        $this->assertJsonStructure(
+            [
+                'type' => 'AdaptiveCard',
+                '$schema' =>
+                    'http://adaptivecards.io/schemas/adaptive-card.json',
+                'version' => '1.0',
+                'msteams' => [
+                    'width' => 'Full',
+                ],
+            ],
+            $card,
+        );
+    }
+
+    /**
+     * @covers AdaptiveCard
+     * @covers AllowExpand
+     */
+    public function testAllowExpand(): void
+    {
+        $card = new AdaptiveCard(
+            body: [
+                new Image(
+                    style: ImageStyle::Person,
+                    url: '${creator.profileImage}',
+                    size: ImageSize::Small,
+                    extensions: [new AllowExpand()],
+                ),
+            ],
+        );
+
+        $this->assertJsonStructure(
+            [
+                'type' => 'AdaptiveCard',
+                '$schema' =>
+                    'http://adaptivecards.io/schemas/adaptive-card.json',
+                'version' => '1.0',
+                'body' => [
+                    [
+                        'type' => 'Image',
+                        'style' => 'person',
+                        'url' => '${creator.profileImage}',
+                        'size' => 'small',
+                        'msteams' => [
+                            'allowExpand' => true,
+                        ],
+                    ],
+                ],
+            ],
+            $card,
+        );
+    }
+
+    /**
+     * @covers AdaptiveCard
+     * @covers TextBlock
+     * @covers Mention
+     */
+    public function testMention(): void
+    {
+        $card = new AdaptiveCard(
+            body: [new TextBlock(text: 'Hello <at>John Doe</at>')],
+            extensions: [
+                new Mention(
+                    text: '<at>John Doe</at>',
+                    id: '29:123124124124',
+                    name: 'John Doe',
+                ),
+            ],
+        );
+
+        $this->assertJsonStructure(
+            [
+                'type' => 'AdaptiveCard',
+                '$schema' =>
+                    'http://adaptivecards.io/schemas/adaptive-card.json',
+                'version' => '1.0',
+                'body' => [
+                    [
+                        'type' => 'TextBlock',
+                        'text' => 'Hello <at>John Doe</at>',
+                    ],
+                ],
+                'msteams' => [
+                    'entities' => [
+                        [
+                            'type' => 'mention',
+                            'text' => '<at>John Doe</at>',
+                            'mentioned' => [
+                                'id' => '29:123124124124',
+                                'name' => 'John Doe',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $card,
+        );
+    }
+
+    /**
+     * @covers AdaptiveCard
+     * @covers TextBlock
+     * @covers Mention
+     */
+    public function testMultipleMentions(): void
+    {
+        $card = new AdaptiveCard(
+            body: [
+                new TextBlock(
+                    text: 'Hello <at>John Doe</at> and <at>Jane Doe</at>',
+                ),
+            ],
+            extensions: [
+                new Mention(
+                    text: '<at>John Doe</at>',
+                    id: '29:123124124124',
+                    name: 'John Doe',
+                ),
+                new Mention(
+                    text: '<at>Jane Doe</at>',
+                    id: '29:123124124125',
+                    name: 'Jane Doe',
+                ),
+            ],
+        );
+
+        $this->assertJsonStructure(
+            [
+                'type' => 'AdaptiveCard',
+                '$schema' =>
+                    'http://adaptivecards.io/schemas/adaptive-card.json',
+                'version' => '1.0',
+                'body' => [
+                    [
+                        'type' => 'TextBlock',
+                        'text' =>
+                            'Hello <at>John Doe</at> and <at>Jane Doe</at>',
+                    ],
+                ],
+                'msteams' => [
+                    'entities' => [
+                        [
+                            'type' => 'mention',
+                            'text' => '<at>John Doe</at>',
+                            'mentioned' => [
+                                'id' => '29:123124124124',
+                                'name' => 'John Doe',
+                            ],
+                        ],
+                        [
+                            'type' => 'mention',
+                            'text' => '<at>Jane Doe</at>',
+                            'mentioned' => [
+                                'id' => '29:123124124125',
+                                'name' => 'Jane Doe',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $card,
+        );
+    }
+
+    /**
+     * Assert that multiple extensions with the same root property (e.g. `msteams`) are merged together correctly
+     *
+     * Merging is done with `array_merge_recursive`, which means that if multiple extensions define the same property, they will be merged into an array. This is the expected behavior for the `entities` property, which can contain multiple mention entities.
+     */
+    public function testMergeBehavior(): void
+    {
+        $one = [
+            'msteams' => ['width' => 'Full'],
+        ];
+
+        $two = [
+            'msteams' => ['allowExpand' => true],
+        ];
+
+        $three = [
+            'msteams' => [
+                'entities' => [
+                    [
+                        'type' => 'mention',
+                        'text' => '<at>John Doe</at>',
+                        'mentioned' => [
+                            'id' => '29:123124124124',
+                            'name' => 'John Doe',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $four = [
+            'msteams' => [
+                'entities' => [
+                    [
+                        'type' => 'mention',
+                        'text' => '<at>Jane Doe</at>',
+                        'mentioned' => [
+                            'id' => '29:123124124125',
+                            'name' => 'Jane Doe',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals(
+            [
+                'msteams' => [
+                    'width' => 'Full',
+                    'allowExpand' => true,
+                    'entities' => [
+                        [
+                            'type' => 'mention',
+                            'text' => '<at>John Doe</at>',
+                            'mentioned' => [
+                                'id' => '29:123124124124',
+                                'name' => 'John Doe',
+                            ],
+                        ],
+                        [
+                            'type' => 'mention',
+                            'text' => '<at>Jane Doe</at>',
+                            'mentioned' => [
+                                'id' => '29:123124124125',
+                                'name' => 'Jane Doe',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            array_merge_recursive($one, $two, $three, $four),
+        );
+    }
+
+    /**
+     * Assert that the card has the expect (valid) JSON structure
+     */
+    private function assertJsonStructure(
+        array $structure,
+        AdaptiveCard $card,
+    ): void {
+        $json = json_encode($card);
+
+        $this->assertNotFalse($json);
+        $this->assertJson($json);
+
+        /** @var array $data */
+        $data = json_decode($json, true);
+
+        $this->assertEquals($structure, $data);
+    }
+}


### PR DESCRIPTION
### Add support for element extensions

All elements have an extensions property to inject custom properties into the elements; for every element there is an unique interface, so injecting extensions for the wrong element is not possible.

The extensions exist as a stopgap for missing properties in the schema. There is currently no up-to-date schema available.

### Add a couple of Microsoft Teams extensions

The first three:

-   Full width Adaptive Card
-   Stageview for images in Adaptive Cards
-   Mention support within Adaptive Cards

Fixes #4, #2